### PR TITLE
PoC on widget resizing

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -12,10 +12,22 @@
 class QmlWidget : public QWidget
 {
 public:
-    QmlWidget() {
-        qml_widget = new QQuickWidget(QUrl("qrc:/main.qml"), this);
+    QmlWidget(QWidget* parent = Q_NULLPTR):
+        QWidget(parent)
+      , qml_widget(new QQuickWidget(QUrl("qrc:/main.qml"), this))
+    {
         qml_widget->setResizeMode(QQuickWidget::SizeRootObjectToView);
+        qml_widget->setMinimumSize(480, 480);
+        setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+        qml_widget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     }
+
+    void resize(const QRect& rect)
+    {
+        QWidget::resize(rect.width(), rect.height());
+        qml_widget->resize(rect.width(), rect.height());
+    }
+
 private:
     QQuickWidget *qml_widget;
 };
@@ -23,21 +35,35 @@ private:
 class MainWindow : public QMainWindow
 {
 public:
-    MainWindow() {
-        QHBoxLayout *layout = new QHBoxLayout();
+    MainWindow():
+        qml_widget(new QmlWidget(this))
+      , layout(new QHBoxLayout())
+    {
+        setCentralWidget(new QWidget(this));
+        //qml_widget->setFixedSize(640,480);
 
-        QmlWidget *qml_widget =  new QmlWidget();
-        qml_widget->setFixedSize(640,480);
+        PrintPreviewWidget *preview_widget =  new PrintPreviewWidget(centralWidget());
+        //preview_widget->setFixedSize(360,480);
 
-        PrintPreviewWidget *preview_widget =  new PrintPreviewWidget();
-        preview_widget->setFixedSize(360,480);
+        layout->addWidget(qml_widget, 2);
+        layout->addWidget(preview_widget, 1);
 
-        layout->addWidget(qml_widget);
-        layout->addWidget(preview_widget);
-
-        setCentralWidget(new QWidget());
         centralWidget()->setLayout(layout);
+        setMinimumSize(640, 480);
+        adjustSize();
     }
+
+protected:
+    void resizeEvent(QResizeEvent* event) override
+    {
+        QMainWindow::resizeEvent(event);
+        const auto itemRect = layout->itemAt(0)->geometry();
+        qml_widget->resize(itemRect);
+    }
+
+private:
+    QmlWidget* qml_widget;
+    QHBoxLayout *layout;
 };
 
 int main(int argc, char** argv)

--- a/main.qml
+++ b/main.qml
@@ -11,8 +11,8 @@ import QtQuick.Controls.Styles 1.4
 
 Rectangle {
     visible: true
-    width: 640
-    height: 480
+    width: parent.height
+    height: parent.width
 
     /* This Rectangle is for the sidebar */
 

--- a/preview.cpp
+++ b/preview.cpp
@@ -1,6 +1,5 @@
 #include "preview.h"
 #include <QPainter>
-#include <QPrinter>
 #include <QPrintPreviewWidget>
 #include <poppler/qt5/poppler-qt5.h>
 #include <QMessageLogger>
@@ -8,15 +7,19 @@
 
 /* This method implements the existing QPrintPreviewWidget class from Qt */
 
-PrintPreviewWidget::PrintPreviewWidget(){
-    printer = new QPrinter();
+PrintPreviewWidget::PrintPreviewWidget(QWidget* parent):
+    QWidget(parent)
+  , printer(new QPrinter{})
+  , preview_widget(new QPrintPreviewWidget(printer.get(), this))
+{
     printer->setPaperSize(QPrinter::A4);
     printer->setOrientation(QPrinter::Portrait);
     printer->setFullPage(true);
 
-    preview_widget = new QPrintPreviewWidget(printer, this);
     connect(preview_widget, SIGNAL(paintRequested(QPrinter*)), this, SLOT(print(QPrinter*)));
 }
+
+PrintPreviewWidget::~PrintPreviewWidget() = default;
 
 void PrintPreviewWidget::print(QPrinter *printer){
     QPainter painter(printer);

--- a/preview.h
+++ b/preview.h
@@ -2,18 +2,22 @@
 #define PREVIEW_H
 
 #include <QWidget>
-#include <QPrinter>
-#include <QPrintPreviewWidget>
+#include <memory>
+
+class QPrinter;
+class QPrintPreviewWidget;
 
 class PrintPreviewWidget : public QWidget
 {
     Q_OBJECT
 public:
-    PrintPreviewWidget();
+    PrintPreviewWidget(QWidget* parent = Q_NULLPTR);
+    ~PrintPreviewWidget();
+
 public slots:
     void print(QPrinter *printer);
 private:
-    QPrinter *printer;
+    std::unique_ptr<QPrinter> printer;
     QPrintPreviewWidget *preview_widget;
 };
 


### PR DESCRIPTION
This is intended to be Proof-of-Concept only. You don't have to merge this.

The resizeEvent should better be handled by signal/slot.

Now, we should also pay more attention to coding style:

- separate header/source into files;
- Qt coding styles;
- header clean-up: pImp/forward declaration, etc.

